### PR TITLE
Improving sequencer, adding SVG image generator

### DIFF
--- a/jquery.roughdraft.js
+++ b/jquery.roughdraft.js
@@ -58,7 +58,10 @@
     // the site to generate lorem ipsum from, for both jsonp + custom options
     author      : 'lorem',
     // the site to generate placeholder images from
-    illustrator : 'placehold',
+    // Possible values:
+    // ["placehold", "placekitten", "placedog", "baconmockup", "lorempixel", "localsvg"]
+    // Defaults: "localsvg" (no HTTP request!)
+    illustrator : 'localsvg',
     // array of categories that should be used (will only work for image generators that allow categories)
     // defaults to all
     // ['abstract', 'animals', 'business', 'cats', 'city', 'food', 'nightlife', 'fashion', 'people', 'nature', 'sports', 'technics', 'transport']
@@ -70,7 +73,7 @@
     customIpsum : false,
     // set timeout for JSONP requests
     timeout: 5000,
-    // Replace occurences of *alfa in classNames following the NATO phonetic alphabet sequence
+    // Replace occurences of *alfa* in classNames following the NATO phonetic alphabet sequence
     classNameSequencer: true,
     // Use local thesaurus to generate one user, see ['localUsers']
     localUserThesaurus: '/roughdraft.thesaurus.json',
@@ -1062,44 +1065,43 @@
     **********************************************/
     _photoAlbum: function(width, height) {
       var photoAlbum = false,
-          illustrator = this.options.illustrator,
-          placeHold = 'placehold',
-          placeKitten = 'placekitten',
-          placeDog = 'placedog',
-          baconMockup = 'baconmockup',
-          loremPixel = 'lorempixel',
-          waterColor,
-          category,
-          imageLink;
+          illustrator = this.options.illustrator
 
-      // if the request (from options), does not match a gallery, return placehold.it default
+          // call the watercolor method to add color and pass the library to it
+          waterColor = this._waterColor(illustrator),
+
+          // call the category method to add a category and pass library to it
+          category = this._category(illustrator),
+
+          imageLink = null;
+
       switch (illustrator) {
-        case placeHold:                     break;
-        case placeKitten:                   break;
-        case placeDog:                      break;
-        case baconMockup:                   break;
-        case loremPixel:                    break;
-        default:  illustrator = placeHold;  break;
-      }
+        case "placehold":
+          imageLink = 'http://placehold.it/' + width + 'x' + height + waterColor;
+        break;
 
-      // call the watercolor method to add color and pass the library to it
-      waterColor = this._waterColor(illustrator);
+        case "placekitten":
+          imageLink = 'http://placekitten.com/' + waterColor + width + '/' + height;
+        break;
 
-      // call the category method to add a category and pass library to it
-      category = this._category(illustrator);
+        case "placedog":
+          imageLink = 'http://placedog.com/' + waterColor + width + '/' + height;
+        break;
 
-      // format the links based on the image gallery with the color/random option, height and width
-      if (illustrator == placeKitten) {
-        imageLink = 'http://placekitten.com/' + waterColor + width + '/' + height;
-      } else if (illustrator == placeDog) {
-        imageLink = 'http://placedog.com/' + waterColor + width + '/' + height;
-      } else if (illustrator == baconMockup) {
-        imageLink = 'http://baconmockup.com/' + width + '/' + height;
-      } else if (illustrator == loremPixel) {
-        imageLink = 'http://lorempixel.com/' + waterColor + width + '/' + height;
-        imageLink += category ? '/' + category : '';
-      } else {
-        imageLink = 'http://placehold.it/' + width + 'x' + height + waterColor;
+        case "baconmockup":
+          imageLink = 'http://baconmockup.com/' + width + '/' + height;
+        break;
+
+        case "lorempixel":
+          imageLink = 'http://lorempixel.com/' + waterColor + width + '/' + height;
+          imageLink += category ? '/' + category : '';
+        break;
+
+        case "localsvg":
+        /* falls through */
+        default:
+          imageLink = this._makeSVGdatauri(width, height, "gray", false);
+        break;
       }
 
       // return string of the resulting image url
@@ -1123,6 +1125,7 @@
           placeKitten = 'placekitten',
           placeDog = 'placedog',
           lorempixel = 'lorempixel',
+          localsvg = null,
           waterColor;
 
       /**
@@ -1198,6 +1201,41 @@
       }
 
       return category;
+    },
+
+    /**********************************************
+     *
+     * Generate a SVG image as a data uri
+     *
+     * @author Doug Schepers <schepers@w3.org>
+     *
+     **********************************************/
+    _makeSVGdatauri: function(width, height, color, wireframes) {
+      var font = "Verdana, sans-serif";
+      var fontsize = 20;
+
+      if (65 > width) {
+        fontsize = width / 4;
+      }
+
+      var fontcolor = "white";
+      if (!color) {
+        color = "gray";
+      } else if ("white" == color) {
+        color = "black";
+      }
+
+      width = parseFloat(width);
+      height = parseFloat(height);
+
+      var svgstr = '<svg xmlns="http://www.w3.org/2000/svg" width="' + width + '" height="' + height + '">';
+      svgstr += '<rect width="100%" height="100%" fill="' + color + '"/>';
+      if (wireframes) {
+        svgstr += '<line x1="0" x2="' + width + '" y1="0" y2="' + height + '" stroke="gainsboro"/><line x1="' + width + '" x2="0" y1="0" y2="' + height + '" stroke="gainsboro"/>';
+      }
+      svgstr += '<text x="' + (width / 2) + '" y="' + ((height / 2) + (fontsize / 4)) + '" font-size="' + fontsize + '" font="' + font + '" fill="white" text-anchor="middle">' + (width + " x " + height) + '</text></svg>';
+
+      return 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svgstr);
     },
 
     /***********************************************

--- a/jquery.roughdraft.js
+++ b/jquery.roughdraft.js
@@ -71,7 +71,7 @@
     // set timeout for JSONP requests
     timeout: 5000,
     // Replace occurences of *alfa in classNames following the NATO phonetic alphabet sequence
-    classNameSequencer: false,
+    classNameSequencer: true,
     // Use local thesaurus to generate one user, see ['localUsers']
     localUserThesaurus: '/roughdraft.thesaurus.json',
     // if customIpsum is true, relative url of library is necessary
@@ -200,10 +200,6 @@
       if ($draftUser.length) {
         this.socialNetwork($draftUser);
       }
-
-      if (this.options.classNameSequencer !== false) {
-        this.sequencer();
-      }
     },
 
 
@@ -242,22 +238,17 @@
       * @author Renoir Boulanger <hello@renoirboulanger.com>
       *
       **********************************************/
-    sequencer: function(){
-        var opt = this.options
-            className = 'alfa',
-            self = this;
-
-        if(opt.classNameSequencer === true){
-          self._sequencerSequence = ['alfa','bravo','charlie','delta','echo','foxtrot','golf','hotel','india','juliet','kilo','lima','mike','november','oscar','papa','quebec','romeo','sierra','tango','uniform','victor','xray','zulu'];
-
-          $('[class$='+className+']').each(function(index){
-              var parent = $(this).parent();
-
-              parent.find('[class$='+className+']').each(function(index){
-                  $(this).attr('class', $(this).attr('class').replace(className, self._sequencerNext(index)));
-              });
-          });
+    sequencerApply: function(element, index) {
+      if(this.options.classNameSequencer === true){
+        var classNames = element.attr("class"),
+            newClassNames = '',
+            e = (!!classNames && /alfa/.test(classNames))?$(element):null;
+        if(e !== null) {
+          newClassNames = classNames.replace('alfa', this._sequencerNext(index));
+          e.attr('class', newClassNames)
+          //console.debug('sequencerApply [element,index]', e, index);
         }
+      }
     },
 
 
@@ -310,10 +301,16 @@
          * loop through the count of requested repeats
          * -1 on the repeat count because the initial instance of the node still exists
          */
-        for (var x = 0; x < repeatCount - 1; x++) {
+        for (var x = 0; x < repeatCount - 1; ++x) {
           // clone true true (with all deep data + events) to maintain node's JS, and insert into dom
-          $self.clone(true, true).insertAfter($self);
+          var cloneMatter = $self.clone(true, true);
+          // Sequencer applied during loop
+          this.sequencerApply(cloneMatter, x);
+          cloneMatter.insertBefore($self);
         }
+
+        // Apply sequencer for the first one too
+        this.sequencerApply($self, repeatCount - 1);
 
         // reset the variables with the data-repeat tags removed, and repeat loop until 0 instances
         $draftRepeat = $('[data-draft-repeat]');
@@ -1520,7 +1517,7 @@
       *  -- Array of words to use as the sequence
       *
     **********************************************/
-    _sequencerSequence: [],
+    _sequencerSequence: ['alfa','bravo','charlie','delta','echo','foxtrot','golf','hotel','india','juliet','kilo','lima','mike','november','oscar','papa','quebec','romeo','sierra','tango','uniform','victor','xray','zulu'],
 
     /**********************************************
       *

--- a/test/index.html
+++ b/test/index.html
@@ -6,35 +6,79 @@
   <script src="//code.jquery.com/jquery-2.1.1.min.js"></script>
   <script src="../jquery.roughdraft.js"></script>
   <script src="js/init_index.js"></script>
+  <style>
+  /* Here is some sample CSS, to give some styling to the demo
+     They are, in no way, required for you to use roughdraft. */
+  .wrapper {
+    margin:10px 20%;
+  }
+  article {
+    padding: 20px;
+  }
+  article+article {
+    margin-top:20px;
+  }
+
+  /* Assuming you want to style elements differently
+     based on a given order, you can leverage class names
+     that mentions alfa in it, it’ll be looped through
+     the sequencer. */
+  .sequencer-alfa {
+    border-left: 3px solid #008B8B; /* cyan */
+  }
+  .sequencer-bravo {
+    border-left: 3px solid #FF00FF; /* magenta */
+  }
+  .sequencer-charlie {
+    border-left: 3px solid #FFFF00; /* yellow */
+  }
+  .sequencer-delta {
+    border-left: 3px solid #000; /* black */
+  }
+
+  .alfa-other-side-works-too {
+    color: #008B8B; /* cyan */
+  }
+  .bravo-other-side-works-too {
+    color: #FF00FF; /* magenta */
+  }
+  .charlie-other-side-works-too {
+    color: #FFFF00; /* yellow */
+  }
+  .delta-other-side-works-too {
+    color: #000; /* black */
+  }
+  </style>
 </head>
 <body>
-
-  <!-- repeats everything within div specified times -->
-  <article data-draft-repeat="3">
-    <header>
-      <h2 itemprop="name" data-draft-text="3/w"></h2>
-      <time>
-        <span data-draft-date="M"></span>
-        <span data-draft-date="d"></span>,
-        <span data-draft-date="Y-r"></span>
-      </time>
-      <p>An article by <a href="#" data-draft-user="twitter"></a></p>
-    </header>
-    <div class="article-body" style="overflow:hidden;">
-      <figure style="float:right;width:200px;">
-        <img data-draft-image="200/120" alt="">
-        <figcaption><span data-draft-text="1/s"></span>&nbsp;—&nbsp;<a href="#" data-draft-user="full"></a>, <span data-draft-user="city"></span>, <span data-draft-user="country"></span></figcaption>
-      </figure>
-      <p data-draft-text="4/s"></p>
-      <ul>
-          <li data-draft-repeat="3" data-draft-text="1/s"></li>
-      </ul>
-      <p data-draft-text="1/s"></p>
-    </div>
-    <div class="article-footer">
-      <p><span data-draft-number="3"></span> shares</p>
-    </div>
-  </article>
-
+  <div class="wrapper">
+  <h1>Hello world!</h1>
+    <!-- repeats everything within div specified times -->
+    <article data-draft-repeat="4" class="sequencer-alfa">
+      <header>
+        <h2 itemprop="name" data-draft-text="3/w"></h2>
+        <time>
+          <span data-draft-date="M"></span>
+          <span data-draft-date="d"></span>,
+          <span data-draft-date="Y-r"></span>
+        </time>
+        <p>An article by <a href="#" data-draft-user="twitter"></a></p>
+      </header>
+      <div class="article-body" style="overflow:hidden;">
+        <figure style="float:right;width:200px;">
+          <img data-draft-image="200/120" alt="">
+          <figcaption><span data-draft-text="1/s"></span>&nbsp;—&nbsp;<a href="#" data-draft-user="full"></a>, <span data-draft-user="city"></span>, <span data-draft-user="country"></span></figcaption>
+        </figure>
+        <p data-draft-text="4/s"></p>
+        <ul>
+            <li data-draft-repeat="3" data-draft-text="1/s" class="alfa-other-side-works-too"></li>
+        </ul>
+        <p data-draft-text="1/s"></p>
+      </div>
+      <div class="article-footer">
+        <p><span data-draft-number="3"></span> shares</p>
+      </div>
+    </article>
+  </div>
 </body>
 </html>

--- a/test/js/init_index.js
+++ b/test/js/init_index.js
@@ -19,7 +19,7 @@ $(function(){
   // FULL OPTIONS
   $(window).roughDraft({
     author      : 'lebowskiipsum.com',
-    illustrator : 'placehold',
+    illustrator : 'localsvg',
     timeout: 5000,
     customIpsum: true,
     customIpsumPath: "../../roughdraft.thesaurus.json",


### PR DESCRIPTION
Here is the promised patch.

What’s new:
1. Refactored sequencer so it change classnames during draft-repeat.
   
   Problem with original classname sequencer is that it’s searching the whole DOM and create sequences. This operation can become intensive; this is why it’s disabled by default.
   
   Instead, how about we only support the class name sequencer to be changed for loops that are already managed in `data-draft-repeat="n"`.  Since we are already looping to clone nodes, we could check if it has the `alfa` trigger in a `class` attribute and, if enabled, replace the cloned node `alfa` className the next name it’s at.
   
   In other words, my suggestion is to support `class="whatever-alfa"` to be sequenced ONLY when that member ALSO has `data-draft-repeat="n"` and make the feature enabled by default.
2. Added SVG image generator
   
   Added a new "photoAlbum", to give auto-generated SVG image through `data-uri`. It’s also suggested to become the default. 
