### PR TITLE
Bumping up version number, pushing to bower with name consistency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "roughdraft",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Quickly create interactive HTML mockups with minimal markup, no server-side code, and without sourcing lorem ipsum text/image generators",
   "homepage": "http://ndreckshage.github.com/roughdraft.js/",
   "dependencies": {


### PR DESCRIPTION
Hi!

I just pushed on bower a package "roughdraft" that should match with the name it was in the `bower.json` file.

Do you want help in maintaining the project?
